### PR TITLE
発言者・メッセージ・削除ボタン・編集ボタンを一行に表示する

### DIFF
--- a/assets/javascripts/index.js
+++ b/assets/javascripts/index.js
@@ -16,27 +16,10 @@ function apple(posts) {
         const li = document.createElement('li');
         li.textContent = post['user']['displayName'];
 
-        const formForDelete = document.createElement('form');
-        formForDelete.setAttribute('action', '/delete_post');
-        formForDelete.setAttribute('method', 'get');
-
-        const hiddenForDelete = document.createElement('input');
-        hiddenForDelete.setAttribute('type', 'hidden');
-        hiddenForDelete.setAttribute('value', '0');
-        hiddenForDelete.setAttribute('id', 'post');
-        hiddenForDelete.setAttribute('name', 'post_id');
-        formForDelete.appendChild(hiddenForDelete);
-
-        const submitForDelete = document.createElement('input');
-        submitForDelete.setAttribute('type', 'submit');
-        submitForDelete.setAttribute('value', '廃棄');
-        formForDelete.appendChild(submitForDelete);
-
-        li.appendChild(formForDelete);
-
         const formForEdit = document.createElement('form');
         formForEdit.setAttribute('action', '/edit_post');
         formForEdit.setAttribute('method', 'get');
+        formForEdit.setAttribute('style', 'display: inline');
 
         const textForEdit = document.createElement('input');
         textForEdit.setAttribute('type', 'text');
@@ -57,6 +40,25 @@ function apple(posts) {
         formForEdit.appendChild(submitForEdit);
 
         li.appendChild(formForEdit);
+
+        const formForDelete = document.createElement('form');
+        formForDelete.setAttribute('action', '/delete_post');
+        formForDelete.setAttribute('method', 'get');
+        formForDelete.setAttribute('style', 'display: inline');
+
+        const hiddenForDelete = document.createElement('input');
+        hiddenForDelete.setAttribute('type', 'hidden');
+        hiddenForDelete.setAttribute('value', '0');
+        hiddenForDelete.setAttribute('id', 'post');
+        hiddenForDelete.setAttribute('name', 'post_id');
+        formForDelete.appendChild(hiddenForDelete);
+
+        const submitForDelete = document.createElement('input');
+        submitForDelete.setAttribute('type', 'submit');
+        submitForDelete.setAttribute('value', '廃棄');
+        formForDelete.appendChild(submitForDelete);
+
+        li.appendChild(formForDelete);
 
         ulElement.appendChild(li);
     }

--- a/views/index.handlebars
+++ b/views/index.handlebars
@@ -3,14 +3,14 @@
   {{#each postList}}
     <li>
       {{this.user.displayName}}
-      <form action="/delete_post" method="get">
-        <input type="hidden" value={{@index}} id="post" name="post_id" />
-        <input type="submit" value="廃棄" />
-      </form>
-      <form action="/edit_post" method="get">
+      <form action="/edit_post" method="get" style="display: inline">
         <input type="text" name="edit_content" value="{{this.message}}" />
         <input type="hidden" value={{@index}} name="post_id" />
         <input type="submit" value="加工" />
+      </form>
+      <form action="/delete_post" method="get" style="display: inline">
+        <input type="hidden" value={{@index}} id="post" name="post_id" />
+        <input type="submit" value="廃棄" />
       </form>
     </li>
   {{/each}}


### PR DESCRIPTION
# Issue
[https://github.com/babyhotate/buri/issues/32](url)

# 内容
- 発言者・メッセージ・削除ボタン・編集ボタンを一行に表示するように修正
- 5秒毎にリダイレクトされる方も修正

# 確認手順
- 画面表示で、発言者・メッセージ・削除ボタン・編集ボタンが横並びになっていることを確認
- 5秒後のリダイレクトでも横並びになっていることを確認

# 課題
- 5秒毎のリダイレクトで、発言者・メッセージ・削除ボタン・編集ボタン同士の間隔に余白がなく、詰まってしまう。
　5秒リダイレクトのためにHTML色々試して挙動合わせていくの辛い。近々Reactの導入を期待して直さない。

![image](https://user-images.githubusercontent.com/47051304/132116310-35cfcd2d-6b49-4228-9a50-c7e755ed4bf4.png)
