### PR TITLE
PostRepositoryのメソッド名をリネーム

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,7 +22,7 @@ const DATA_DIR_PATH = 'data';
  */
 app.get('/', (req, res) => {
   const postRepository = new PostRepository(DATA_DIR_PATH);
-  const postList = postRepository.getPosts();
+  const postList = postRepository.findAll();
   const userIds = postList.map(post => post.userId);
 
   const userRepository = new UserRepository(DATA_DIR_PATH);
@@ -44,7 +44,7 @@ app.get('/', (req, res) => {
  */
 app.get('/api/posts', (req, res) => {
   const postRepository = new PostRepository(DATA_DIR_PATH);
-  const postList = postRepository.getPosts();
+  const postList = postRepository.findAll();
   const userIds = postList.map(post => post.userId);
 
   const userRepository = new UserRepository(DATA_DIR_PATH);
@@ -66,7 +66,7 @@ app.get('/api/posts', (req, res) => {
  */
 app.get('/add_post', (req, res) => {
   const postRepository = new PostRepository(DATA_DIR_PATH);
-  postRepository.writePost(req.query.user, req.query.post);
+  postRepository.create(req.query.user, req.query.post);
   res.redirect('/');
 });
 
@@ -76,7 +76,7 @@ app.get('/add_post', (req, res) => {
  */
 app.get('/delete_post', (req, res) => {
   const postRepository = new PostRepository(DATA_DIR_PATH);
-  postRepository.deletePost(req.query.post_id);
+  postRepository.delete(req.query.post_id);
   res.redirect('/');
 });
 
@@ -86,7 +86,7 @@ app.get('/delete_post', (req, res) => {
  */
 app.get("/edit_post", (req, res) => {
   const postRepository = new PostRepository(DATA_DIR_PATH);
-  postRepository.editPost(req.query.post_id, req.query.edit_content);
+  postRepository.update(req.query.post_id, req.query.edit_content);
   res.redirect('/');
 });
 

--- a/repositories/postRepository.js
+++ b/repositories/postRepository.js
@@ -8,7 +8,7 @@ class PostRepository {
         this.filePath = `${dataDirPath}/posts.txt`;
     }
 
-    getPosts() {
+    findAll() {
         if (!fs.existsSync(this.filePath)) {
             fs.writeFileSync(this.filePath, "");
         }
@@ -25,12 +25,12 @@ class PostRepository {
         return models;
     }
 
-    writePost(userId, message) {
-        const postList = this.getPosts();
+    create(userId, message) {
+        const postList = this.findAll();
         const latestId = postList[postList.length - 1].id;
         const post = new Post(userId, message, Number(latestId) + 1);
         try {
-          const postList = this.getPosts();
+          const postList = this.findAll();
           // なんかよくわからないが空ファイルも、1行の空行があるように見えてしまう
           // ので、全くの空かどうかで書き込み方を切り替える必要がある
           if (postList.length > 0) {
@@ -44,8 +44,8 @@ class PostRepository {
     }
 
     // @params index {Number}
-    deletePost(index) {
-        const postList = this.getPosts();
+    delete(index) {
+        const postList = this.findAll();
         postList.splice(index, 1);
         const postStringLines = postList.map((p) => p.userId + "," + p.message + "," + p.id);
         const lines = postStringLines.join("\n");
@@ -56,8 +56,8 @@ class PostRepository {
     }
 
     // @params index {Number}
-    editPost(index, edit_content) {
-        const postList = this.getPosts();
+    update(index, edit_content) {
+        const postList = this.findAll();
         const editedPost = new Post(postList[index].userId, edit_content, postList[index].id);
         postList[index] = editedPost;
         const postStringLines = postList.map((p) => p.userId + "," + p.message + "," + p.id);

--- a/test/postRepository.test.js
+++ b/test/postRepository.test.js
@@ -12,9 +12,9 @@ beforeEach(() => {
     fs.writeFileSync(POSTS_FILE_PATH, ["user1,hoge,1", "user2,fuga,2"].join("\n"));
 });
 
-describe('#getPosts', () => {
+describe('#findAll', () => {
     test('post全件が取得できる', () => {
-        const posts = postRepository.getPosts();
+        const posts = postRepository.findAll();
         expect(posts.length).toBe(2);
         expect(posts[0].userId).toBe("user1");
         expect(posts[0].message).toBe("hoge");
@@ -25,9 +25,9 @@ describe('#getPosts', () => {
     });
 });
 
-describe("#writePost", () => {
+describe("#create", () => {
   test("1件の投稿をデータストアに書き込む", () => {
-    postRepository.writePost("user1", "piyo");
+    postRepository.create("user1", "piyo");
 
     let posts = fs.readFileSync(POSTS_FILE_PATH, "utf-8");
     posts = posts.split("\n");
@@ -35,9 +35,9 @@ describe("#writePost", () => {
   });
 });
 
-describe('#deletePost', () => {
+describe('#delete', () => {
     test('1件の投稿を削除する', () => {
-        postRepository.deletePost(1);
+        postRepository.delete(1);
 
         let posts = fs.readFileSync(POSTS_FILE_PATH, 'utf-8');
         posts = posts.split("\n");
@@ -47,9 +47,9 @@ describe('#deletePost', () => {
     });
 });
 
-describe('#editPost', () => {
+describe('#update', () => {
     test('1件の投稿を編集する', () => {
-        postRepository.editPost(1, 'fuga2');
+        postRepository.update(1, 'fuga2');
 
         let posts = fs.readFileSync(POSTS_FILE_PATH, 'utf-8');
         posts = posts.split("\n");


### PR DESCRIPTION
理由
- メソッド名にpostsは不要だから
- writeやeditだと「ファイルに書き込む」イメージがあり、リポジトリの役割に合わない
- よりリポジトリのメソッドっぽい名前にしたい