### PR TITLE
RepositoryのgetByXXX系の関数で空配列かどうかチェックする

### DIFF
--- a/repositories/userRepository.js
+++ b/repositories/userRepository.js
@@ -25,6 +25,11 @@ class UserRepository {
   }
 
   static async getByUserIds(connection, userIds) {
+    if (userIds.length === 0) {
+      // 空配列を渡すと空のIN句が生成されて SQL syntax error が発生する
+      throw new Error("userIds には空配列を指定できません");
+    }
+
     const [rows] = await connection.query(
       `SELECT * FROM ${this.tableName} WHERE user_id in (?)`,
       [userIds]
@@ -35,6 +40,11 @@ class UserRepository {
   }
 
   static async getByIds(connection, ids) {
+    if (ids.length === 0) {
+      // 空配列を渡すと空のIN句が生成されて SQL syntax error が発生する
+      throw new Error("ids には空配列を指定できません");
+    }
+
     const [rows] = await connection.query(
       `SELECT * FROM ${this.tableName} WHERE id in (?)`,
       [ids]

--- a/test/userRepository.test.js
+++ b/test/userRepository.test.js
@@ -61,6 +61,10 @@ describe("#getByIds", () => {
     ]);
     expect(users).toEqual(expectUsers);
   });
+  test("空配列が指定された時に例外が発生すること", async () => {
+    const promise = UserRepository.getByIds(connection, []);
+    await expect(promise).rejects.toThrow('ids には空配列を指定できません');
+  });
 });
 
 describe("#getByUserIds", () => {
@@ -86,6 +90,10 @@ describe("#getByUserIds", () => {
     ]);
     expect(users).toEqual(expectUsers);
   });
+  test("空配列が指定された時に例外が発生すること", async () => {
+    const promise = UserRepository.getByUserIds(connection, []);
+    await expect(promise).rejects.toThrow('userIds には空配列を指定できません');
+  })
 });
 
 describe("#getAll", () => {


### PR DESCRIPTION
https://github.com/babyhotate/buri/pull/96 の本格対処版

# やりたいこと
- repository の `getByXXX()` を使う側の処理を実装する開発者が気付きやすいようにしたい