### PR TITLE
posts.user_idカラムの外部キー制約の間違いを修正

### DIFF
--- a/data/init.sql
+++ b/data/init.sql
@@ -13,5 +13,5 @@ CREATE TABLE `posts` (
   `user_id` int unsigned NOT NULL,
   `message` varchar(1000) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
-  CONSTRAINT `user_id` FOREIGN KEY (`id`) REFERENCES `users` (`id`)
+  FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;


### PR DESCRIPTION
# やりたいこと
- `user_id` ではなく、 `id` に外部キー制約がついてしまっていたのを直す

# 仮設
- `posts` テーブルに、複数回INSERTしていくうちに、 auto increment している `posts.id` カラムが `users.id` に存在しないIDを使うようになってしまったと思われる
  - 最初はエラーにならないが、時間経過でエラーが発生する理由も説明がつく

# 備考
- 制約名は指定せず、MySQLが勝手に作ってくれるのに任せることにしてみた